### PR TITLE
Added levepipe to GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: install llvmpipe and lavapipe
+        run: |
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/e2e-tests/tests/test_env.rs
+++ b/e2e-tests/tests/test_env.rs
@@ -60,11 +60,9 @@ fn cpu_render(composition: &mut Composition, width: usize, height: usize) -> Rgb
 
 fn gpu_render(composition: &mut Composition, width: usize, height: usize) -> RgbaImage {
     let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
-    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        ..Default::default()
-    }))
-    .expect("failed to find an appropriate adapter");
+    let adapter =
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
+            .expect("failed to find an appropriate adapter");
 
     let (device, queue) = pollster::block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
@@ -72,7 +70,7 @@ fn gpu_render(composition: &mut Composition, width: usize, height: usize) -> Rgb
             features: Default::default(),
             limits: wgpu::Limits {
                 max_texture_dimension_2d: 8192,
-                max_storage_buffer_binding_size: 1 << 30,
+                max_storage_buffer_binding_size: 1 << 27,
                 ..wgpu::Limits::downlevel_defaults()
             },
         },


### PR DESCRIPTION
Previous CI was broken since there is no GPU support on GitHub Actions. This will now uses lavapipe instead.