### PR TITLE
Fix missing texture

### DIFF
--- a/demo/src/demos/texture.rs
+++ b/demo/src/demos/texture.rs
@@ -36,7 +36,7 @@ impl Texture {
             width: 1000,
             height: 1000,
             time: Duration::ZERO,
-            image: load_image(&PathBuf::from("assets/image/butterfly.jpg")),
+            image: load_image(&PathBuf::from("assets/images/logo.png")),
         }
     }
 


### PR DESCRIPTION
This fixes the missing file error while running the texture demo with the command `cargo run --release -p demo -- texture`