### PR TITLE
Fix `texture` demo so it finds an image to rotate

### DIFF
--- a/demo/src/demos/texture.rs
+++ b/demo/src/demos/texture.rs
@@ -33,10 +33,10 @@ pub struct Texture {
 impl Texture {
     pub fn new() -> Self {
         Self {
-            width: 1000,
-            height: 1000,
+            width: 800,
+            height: 800,
             time: Duration::ZERO,
-            image: load_image(&PathBuf::from("assets/image/butterfly.jpg")),
+            image: load_image(&PathBuf::from("assets/images/juice.png")),
         }
     }
 


### PR DESCRIPTION
Folder path was wrong and `butterfly.jpg` was not in the repo.  Switched to `juice.png`.