### PR TITLE
Added line culling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Unreleased
+
+* Added line-culling to `SegmentBuffer` in #29

--- a/forma/src/composition/mod.rs
+++ b/forma/src/composition/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+use std::cell::Ref;
 use std::{cell::RefCell, rc::Rc};
 
 use rustc_hash::FxHashMap;
@@ -379,6 +381,19 @@ impl Composition {
                 .expect("lines_builder should not be None")
                 .retain(|id| geom_id_to_order.contains_key(&id));
         }
+    }
+
+    #[cfg(test)]
+    pub fn layers_for_segments(
+        &self,
+    ) -> (
+        &FxHashMap<Order, Layer>,
+        Ref<FxHashMap<GeomId, Option<Order>>>,
+    ) {
+        (
+            &self.layers,
+            Ref::map(self.shared_state.borrow(), |state| &state.geom_id_to_order),
+        )
     }
 }
 

--- a/forma/src/cpu/painter/mod.rs
+++ b/forma/src/cpu/painter/mod.rs
@@ -962,7 +962,7 @@ mod tests {
 
         let (layers, geom_id_to_order) = composition.layers_for_segments();
 
-        let lines = segment_buffer.fill_cpu_view(1000, 1000, layers, &geom_id_to_order);
+        let lines = segment_buffer.fill_cpu_view(usize::MAX, usize::MAX, layers, &geom_id_to_order);
 
         let mut rasterizer = Rasterizer::default();
         rasterizer.rasterize(&lines);

--- a/forma/src/cpu/painter/mod.rs
+++ b/forma/src/cpu/painter/mod.rs
@@ -792,16 +792,16 @@ pub fn painter_fill_at_bench(width: usize, height: usize, style: &Style) -> f32x
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     use std::{collections::HashMap, iter};
 
     use crate::{
-        composition::InnerLayer,
         consts::cpu::{TILE_HEIGHT, TILE_WIDTH},
         cpu::{buffer::layout::LinearLayout, Rasterizer, RGBA},
         math::Point,
-        GeomId, Order, SegmentBuffer,
+        Composition, GeomId, Order, SegmentBuffer,
     };
 
     const RED: Color = Color {
@@ -944,20 +944,25 @@ mod tests {
         points: &[(Point, Point)],
         same_layer: bool,
     ) -> Vec<PixelSegment<TILE_WIDTH, TILE_HEIGHT>> {
-        let mut builder = SegmentBuffer::default();
-        let ids = iter::successors(Some(GeomId::default()), |id| Some(id.next()));
+        let mut segment_buffer = SegmentBuffer::default();
+        let mut composition = Composition::new();
 
-        for (&(p0, p1), id) in points.iter().zip(ids) {
-            let id = if same_layer { GeomId::default() } else { id };
-            builder.push(id, [p0, p1]);
+        if same_layer {
+            composition.get_mut_or_insert_default(Order::new(0).unwrap());
+
+            for &(p0, p1) in points.iter() {
+                segment_buffer.push(GeomId::default(), [p0, p1]);
+            }
+        } else {
+            for (id, &(p0, p1)) in points.iter().enumerate() {
+                composition.get_mut_or_insert_default(Order::new(id as u32).unwrap());
+                segment_buffer.push(GeomId::new(id as u64), [p0, p1]);
+            }
         }
 
-        let lines = builder.fill_cpu_view(|id| {
-            Some(InnerLayer {
-                order: Some(Order::new(id.get() as u32).unwrap()),
-                ..Default::default()
-            })
-        });
+        let (layers, geom_id_to_order) = composition.layers_for_segments();
+
+        let lines = segment_buffer.fill_cpu_view(1000, 1000, layers, &geom_id_to_order);
 
         let mut rasterizer = Rasterizer::default();
         rasterizer.rasterize(&lines);

--- a/forma/src/cpu/rasterizer.rs
+++ b/forma/src/cpu/rasterizer.rs
@@ -186,7 +186,7 @@ mod tests {
 
         let (layers, geom_id_to_order) = composition.layers_for_segments();
 
-        let lines = segment_buffer.fill_cpu_view(1000, 1000, layers, &geom_id_to_order);
+        let lines = segment_buffer.fill_cpu_view(usize::MAX, usize::MAX, layers, &geom_id_to_order);
 
         let mut rasterizer = Rasterizer::default();
         rasterizer.rasterize(&lines);

--- a/forma/src/cpu/rasterizer.rs
+++ b/forma/src/cpu/rasterizer.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn area_cover_octant_5() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(-3.0, -2.0))),
+            areas_and_covers(&segments(Point::new(3.0, 2.0), Point::new(0.0, 0.0))),
             [
                 (-(11 * 16), -11),
                 (-(5 * 8), -5),
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn area_cover_octant_6() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(-2.0, -3.0))),
+            areas_and_covers(&segments(Point::new(2.0, 3.0), Point::new(0.0, 0.0))),
             [
                 (-(16 * 11), -16),
                 (-(8 * 5 + 2 * (8 * 11)), -8),
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn area_cover_octant_7() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(2.0, -3.0))),
+            areas_and_covers(&segments(Point::new(0.0, 3.0), Point::new(2.0, 0.0))),
             [
                 (-(16 * 11 + 2 * (16 * 5)), -16),
                 (-(8 * 5), -8),
@@ -337,7 +337,7 @@ mod tests {
     #[test]
     fn area_cover_octant_8() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(3.0, -2.0))),
+            areas_and_covers(&segments(Point::new(0.0, 2.0), Point::new(3.0, 0.0))),
             [
                 (-(11 * 16), -11),
                 (-(5 * 8 + 2 * (5 * 8)), -5),
@@ -390,7 +390,7 @@ mod tests {
     #[test]
     fn area_cover_axis_225() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(-1.0, -1.0))),
+            areas_and_covers(&segments(Point::new(1.0, 1.0), Point::new(0.0, 0.0))),
             [(-(16 * 16), -16)],
         );
     }
@@ -398,7 +398,7 @@ mod tests {
     #[test]
     fn area_cover_axis_270() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(0.0, -1.0))),
+            areas_and_covers(&segments(Point::new(0.0, 1.0), Point::new(0.0, 0.0))),
             [(2 * -(16 * 16), -16)],
         );
     }
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn area_cover_axis_315() {
         assert_eq!(
-            areas_and_covers(&segments(Point::new(0.0, 0.0), Point::new(-1.0, -1.0))),
+            areas_and_covers(&segments(Point::new(0.0, 1.0), Point::new(1.0, 0.0))),
             [(-(16 * 16), -16)],
         );
     }

--- a/forma/src/cpu/rasterizer.rs
+++ b/forma/src/cpu/rasterizer.rs
@@ -169,7 +169,7 @@ mod tests {
     use super::*;
 
     use crate::{
-        composition::InnerLayer,
+        composition::Composition,
         consts::cpu::{TILE_HEIGHT, TILE_WIDTH},
         math::Point,
         segment::{GeomId, SegmentBuffer},
@@ -177,14 +177,16 @@ mod tests {
     };
 
     fn segments(p0: Point, p1: Point) -> Vec<PixelSegment<TILE_WIDTH, TILE_HEIGHT>> {
-        let mut builder = SegmentBuffer::default();
-        builder.push(GeomId::default(), [p0, p1]);
-        let lines = builder.fill_cpu_view(|_| {
-            Some(InnerLayer {
-                order: Some(Order::new(0).unwrap()),
-                ..Default::default()
-            })
-        });
+        let mut segment_buffer = SegmentBuffer::default();
+        let mut composition = Composition::new();
+
+        composition.get_mut_or_insert_default(Order::new(0).unwrap());
+
+        segment_buffer.push(GeomId::default(), [p0, p1]);
+
+        let (layers, geom_id_to_order) = composition.layers_for_segments();
+
+        let lines = segment_buffer.fill_cpu_view(1000, 1000, layers, &geom_id_to_order);
 
         let mut rasterizer = Rasterizer::default();
         rasterizer.rasterize(&lines);
@@ -481,14 +483,14 @@ mod tests {
     fn tile_octant_5() {
         assert_eq!(
             tiles(&segments(
-                Point::new(-(TILE_WIDTH as f32), -(TILE_HEIGHT as f32)),
-                Point::new(-(TILE_WIDTH as f32) - 3.0, -(TILE_HEIGHT as f32) - 2.0),
+                Point::new(-(TILE_WIDTH as f32), TILE_HEIGHT as f32),
+                Point::new(-(TILE_WIDTH as f32) - 3.0, TILE_HEIGHT as f32 - 2.0),
             )),
             [
-                (-1, -1, TILE_WIDTH as u8 - 1, TILE_HEIGHT as u8 - 1),
-                (-1, -1, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 1),
-                (-1, -1, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 2),
-                (-1, -1, TILE_WIDTH as u8 - 3, TILE_HEIGHT as u8 - 2),
+                (-1, 0, TILE_WIDTH as u8 - 1, TILE_HEIGHT as u8 - 1),
+                (-1, 0, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 1),
+                (-1, 0, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 2),
+                (-1, 0, TILE_WIDTH as u8 - 3, TILE_HEIGHT as u8 - 2),
             ],
         );
     }
@@ -497,14 +499,14 @@ mod tests {
     fn tile_octant_6() {
         assert_eq!(
             tiles(&segments(
-                Point::new(-(TILE_WIDTH as f32), -(TILE_HEIGHT as f32)),
-                Point::new(-(TILE_WIDTH as f32) - 2.0, -(TILE_HEIGHT as f32) - 3.0),
+                Point::new(-(TILE_WIDTH as f32), TILE_HEIGHT as f32),
+                Point::new(-(TILE_WIDTH as f32) - 2.0, TILE_HEIGHT as f32 - 3.0),
             )),
             [
-                (-1, -1, TILE_WIDTH as u8 - 1, TILE_HEIGHT as u8 - 1),
-                (-1, -1, TILE_WIDTH as u8 - 1, TILE_HEIGHT as u8 - 2),
-                (-1, -1, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 2),
-                (-1, -1, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 3),
+                (-1, 0, TILE_WIDTH as u8 - 1, TILE_HEIGHT as u8 - 1),
+                (-1, 0, TILE_WIDTH as u8 - 1, TILE_HEIGHT as u8 - 2),
+                (-1, 0, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 2),
+                (-1, 0, TILE_WIDTH as u8 - 2, TILE_HEIGHT as u8 - 3),
             ],
         );
     }
@@ -513,14 +515,14 @@ mod tests {
     fn tile_octant_7() {
         assert_eq!(
             tiles(&segments(
-                Point::new(TILE_WIDTH as f32, -(TILE_HEIGHT as f32)),
-                Point::new(TILE_WIDTH as f32 + 2.0, -(TILE_HEIGHT as f32) - 3.0),
+                Point::new(TILE_WIDTH as f32, TILE_HEIGHT as f32),
+                Point::new(TILE_WIDTH as f32 + 2.0, (TILE_HEIGHT as f32) - 3.0),
             )),
             [
-                (1, -1, 0, TILE_HEIGHT as u8 - 1),
-                (1, -1, 0, TILE_HEIGHT as u8 - 2),
-                (1, -1, 1, TILE_HEIGHT as u8 - 2),
-                (1, -1, 1, TILE_HEIGHT as u8 - 3),
+                (1, 0, 0, TILE_HEIGHT as u8 - 1),
+                (1, 0, 0, TILE_HEIGHT as u8 - 2),
+                (1, 0, 1, TILE_HEIGHT as u8 - 2),
+                (1, 0, 1, TILE_HEIGHT as u8 - 3),
             ],
         );
     }
@@ -529,14 +531,14 @@ mod tests {
     fn tile_octant_8() {
         assert_eq!(
             tiles(&segments(
-                Point::new(TILE_WIDTH as f32, -(TILE_HEIGHT as f32)),
-                Point::new(TILE_WIDTH as f32 + 3.0, -(TILE_HEIGHT as f32) - 2.0),
+                Point::new(TILE_WIDTH as f32, TILE_HEIGHT as f32),
+                Point::new(TILE_WIDTH as f32 + 3.0, (TILE_HEIGHT as f32) - 2.0),
             )),
             [
-                (1, -1, 0, TILE_HEIGHT as u8 - 1),
-                (1, -1, 1, TILE_HEIGHT as u8 - 1),
-                (1, -1, 1, TILE_HEIGHT as u8 - 2),
-                (1, -1, 2, TILE_HEIGHT as u8 - 2),
+                (1, 0, 0, TILE_HEIGHT as u8 - 1),
+                (1, 0, 1, TILE_HEIGHT as u8 - 1),
+                (1, 0, 1, TILE_HEIGHT as u8 - 2),
+                (1, 0, 2, TILE_HEIGHT as u8 - 2),
             ],
         );
     }

--- a/forma/src/gpu/rasterizer/mod.rs
+++ b/forma/src/gpu/rasterizer/mod.rs
@@ -250,17 +250,14 @@ impl GpuContext for RasterizerContext {
 mod tests {
     use super::*;
 
-    use std::collections::HashMap;
-
     use rand::{distributions::Uniform, prelude::*};
 
     use crate::{
-        composition::InnerLayer,
         consts::gpu::{TILE_HEIGHT, TILE_WIDTH},
         cpu::{PixelSegment, Rasterizer},
         math::Point,
         segment::{GeomId, SegmentBuffer},
-        Order, PathBuilder,
+        Composition, Order, PathBuilder,
     };
 
     fn run_rasterizer(
@@ -332,14 +329,16 @@ mod tests {
             .build();
 
         let mut segment_buffer = SegmentBuffer::default();
+        let mut composition = Composition::new();
+
         segment_buffer.push_path(GeomId::default(), &path);
 
-        let segment_buffer_view = segment_buffer.fill_gpu_view(|_| {
-            Some(InnerLayer {
-                order: Some(Order::new(1).unwrap()),
-                ..Default::default()
-            })
-        });
+        composition.get_mut_or_insert_default(Order::new(1).unwrap());
+
+        let (layers, geom_id_to_order) = composition.layers_for_segments();
+
+        let segment_buffer_view =
+            segment_buffer.fill_gpu_view(1000, 1000, layers, &geom_id_to_order);
 
         let (actual_segments, _) = run_rasterizer(segment_buffer_view);
         let expected_segments = [
@@ -358,6 +357,7 @@ mod tests {
     #[test]
     fn rasterize_random_quad() {
         let mut segment_buffer = SegmentBuffer::default();
+        let mut composition = Composition::new();
         let mut rng = SmallRng::seed_from_u64(0);
 
         // Using a small range to workaround the precision difference between CPU and GPU
@@ -369,8 +369,6 @@ mod tests {
         };
 
         let mut geom_id = GeomId::default();
-        let mut geom_id_to_order = HashMap::new();
-        let mut order = 0;
 
         for _ in 0..4096 {
             let path = PathBuilder::new()
@@ -380,21 +378,17 @@ mod tests {
                 .line_to(rnd_point())
                 .build();
 
+            composition.get_mut_or_insert_default(Order::new(geom_id.get() as u32).unwrap());
+
             segment_buffer.push_path(geom_id, &path);
-            geom_id_to_order.insert(geom_id, Order::new(order).unwrap());
             geom_id = geom_id.next();
-            order += 1;
         }
 
-        let layers = |geom_id| {
-            Some(InnerLayer {
-                order: geom_id_to_order.get(&geom_id).copied(),
-                ..Default::default()
-            })
-        };
+        let (layers, geom_id_to_order) = composition.layers_for_segments();
 
         let gpu_segments = {
-            let segment_buffer_view = segment_buffer.fill_gpu_view(layers);
+            let segment_buffer_view =
+                segment_buffer.fill_gpu_view(1000, 1000, layers, &geom_id_to_order);
             let (segments, segment_buffer_view) = run_rasterizer(segment_buffer_view);
             segment_buffer = segment_buffer_view.recycle();
 
@@ -402,7 +396,8 @@ mod tests {
         };
 
         let mut cpu_segments = {
-            let segment_buffer_view = segment_buffer.fill_cpu_view(layers);
+            let segment_buffer_view =
+                segment_buffer.fill_cpu_view(1000, 1000, layers, &geom_id_to_order);
             let mut rasterizer = Rasterizer::<TILE_WIDTH, TILE_HEIGHT>::default();
             rasterizer.rasterize(&segment_buffer_view);
 

--- a/forma/src/gpu/rasterizer/mod.rs
+++ b/forma/src/gpu/rasterizer/mod.rs
@@ -338,7 +338,7 @@ mod tests {
         let (layers, geom_id_to_order) = composition.layers_for_segments();
 
         let segment_buffer_view =
-            segment_buffer.fill_gpu_view(1000, 1000, layers, &geom_id_to_order);
+            segment_buffer.fill_gpu_view(usize::MAX, usize::MAX, layers, &geom_id_to_order);
 
         let (actual_segments, _) = run_rasterizer(segment_buffer_view);
         let expected_segments = [
@@ -388,7 +388,7 @@ mod tests {
 
         let gpu_segments = {
             let segment_buffer_view =
-                segment_buffer.fill_gpu_view(1000, 1000, layers, &geom_id_to_order);
+                segment_buffer.fill_gpu_view(usize::MAX, usize::MAX, layers, &geom_id_to_order);
             let (segments, segment_buffer_view) = run_rasterizer(segment_buffer_view);
             segment_buffer = segment_buffer_view.recycle();
 
@@ -397,7 +397,7 @@ mod tests {
 
         let mut cpu_segments = {
             let segment_buffer_view =
-                segment_buffer.fill_cpu_view(1000, 1000, layers, &geom_id_to_order);
+                segment_buffer.fill_cpu_view(usize::MAX, usize::MAX, layers, &geom_id_to_order);
             let mut rasterizer = Rasterizer::<TILE_WIDTH, TILE_HEIGHT>::default();
             rasterizer.rasterize(&segment_buffer_view);
 

--- a/forma/src/gpu/renderer/mod.rs
+++ b/forma/src/gpu/renderer/mod.rs
@@ -483,14 +483,7 @@ impl Renderer {
         let segment_buffer_view = segment_buffer
             .take()
             .expect("segment_buffer should not be None")
-            .fill_gpu_view(|id| {
-                geom_id_to_order
-                    .get(&id)
-                    .copied()
-                    .flatten()
-                    .and_then(|order| layers.get(&order))
-                    .map(|layer| layer.inner.clone())
-            });
+            .fill_gpu_view(width as usize, height as usize, layers, geom_id_to_order);
 
         self.styling_map.populate(layers);
 

--- a/forma/src/segment.rs
+++ b/forma/src/segment.rs
@@ -38,6 +38,19 @@ fn transform_point(point: (f32, f32), transform: &AffineTransform) -> (f32, f32)
     )
 }
 
+fn skip_line(p0x: f32, p0y: f32, p1x: f32, p1y: f32, width: f32, height: f32) -> bool {
+    // Vertical lines do no create coverage information.
+    let is_vertical = p0y == p1y;
+
+    // We can skip everything to the top, right, and bottom, but not left. Lines to the left might
+    // produce coverage that affects the render target.
+    let is_over = p0y > height && p1y > height;
+    let is_to_the_right = p0x > width && p1x > width;
+    let is_under = p0y < 0.0 && p1y < 0.0;
+
+    is_vertical || is_over || is_to_the_right || is_under
+}
+
 fn integers_between(a: f32, b: f32) -> u32 {
     let min = a.min(b);
     let max = a.max(b);
@@ -311,12 +324,7 @@ impl SegmentBuffer {
                 (p0x, p0y, p1x, p1y)
             };
 
-            let skip = p0y == p1y
-                || p0y < 0.0 && p1y < 0.0
-                || p0y > height && p1y > height
-                || p0x > width && p1x > width;
-
-            if skip {
+            if skip_line(p0x, p0y, p1x, p1y, width, height) {
                 return empty_line;
             }
 
@@ -496,12 +504,7 @@ impl SegmentBuffer {
                 (p0x, p0y)
             };
 
-            let skip = p0y == p1y
-                || p0y < 0.0 && p1y < 0.0
-                || p0y > height && p1y > height
-                || p0x > width && p1x > width;
-
-            if skip {
+            if skip_line(p0x, p0y, p1x, p1y, width, height) {
                 return empty_line;
             }
 

--- a/forma/src/segment.rs
+++ b/forma/src/segment.rs
@@ -44,9 +44,9 @@ fn skip_line(p0x: f32, p0y: f32, p1x: f32, p1y: f32, width: f32, height: f32) ->
 
     // We can skip everything to the top, right, and bottom, but not left. Lines to the left might
     // produce coverage that affects the render target.
-    let is_over = p0y > height && p1y > height;
-    let is_to_the_right = p0x > width && p1x > width;
-    let is_under = p0y < 0.0 && p1y < 0.0;
+    let is_over = p0y >= height && p1y >= height;
+    let is_to_the_right = p0x >= width && p1x >= width;
+    let is_under = p0y <= 0.0 && p1y <= 0.0;
 
     is_vertical || is_over || is_to_the_right || is_under
 }


### PR DESCRIPTION
This adds line culling in the SegmentBuffer where possible. In our case, this means top, right, and bottom of the render area.

This also refactors part of the SegmentBuffer which improves time spent filling it by around 40%.

It also improves super zoomed-in SVGs:

```sh
cargo run --release -p demo -- svg assets/svgs/paris-30k.svg -s 20
```

This went from 250ms to 12ms on an M1 Pro. Fixes #25.