### PR TITLE
Add simple controls to the svg renderer

### DIFF
--- a/demo/src/demos/svg.rs
+++ b/demo/src/demos/svg.rs
@@ -904,16 +904,18 @@ impl App for Svg {
         for (order, (path, fill_rule, fill, blend_mode)) in self.paths.iter().enumerate() {
             let mut layer = composition.create_layer();
 
-            layer.insert(path).set_props(Props {
-                fill_rule: *fill_rule,
-                func: Func::Draw(Style {
-                    fill: fill.clone(),
-                    blend_mode: *blend_mode,
-                    ..Default::default()
-                }),
-            });
-            layer.set_transform(transform);
-            // .set_transform(transform);
+            layer
+                .insert(path)
+                .set_transform(transform)
+                .set_props(Props {
+                    fill_rule: *fill_rule,
+                    func: Func::Draw(Style {
+                        fill: fill.clone(),
+                        blend_mode: *blend_mode,
+                        ..Default::default()
+                    }),
+                });
+
             composition.insert(Order::new(order as u32).unwrap(), layer);
         }
 


### PR DESCRIPTION
Pressing <kbd>←</kbd> moves the image left, <kbd>→</kbd> moves the image right (<kbd>↑</kbd>, <kbd>↓</kbd>, up and down, respectively). These controls are frame-rate independent, although because the rendering time is so large (~110ms at scale 4 and default window size on my machine), this is still a bit jumpy

I have noticed that the performance of the renderer appears to be $O(f(scale))$, where $f$ is sublinear. This suggests that at least one part of the pipeline is linear in the scale, presumably because each individual path is flattened into more line/pixel segments? I would have thought clipping would have made that not a concern, but I haven't looked too deeply into it. This is on the CPU runner. Performance is slightly better on the GPU runner.

To test in a useful form, use:
```sh
cargo run --release -p demo -- svg assets/svgs/paris-30k.svg --scale 3
```